### PR TITLE
Freeze redis version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ xlrd == 1.1.0
 xlwt == 1.3.0
 xlutils == 2.0.0
 psycopg2-binary == 2.7.5
-django-redis == 4.9.0
+redis == 3.0.1
+django-redis == 4.10.0
 django-fsm == 2.6.0
 django-webtest == 1.9.3
 WebTest == 2.0.30


### PR DESCRIPTION
freeze redis version because 3.0 causes troubles (`manage.py refresh_results_cache` on `vagrant up` already throws errors about the `CacheKey` being invalid)