### PR TITLE
translate warning descriptors lazily

### DIFF
--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -3,7 +3,7 @@ import xlrd
 
 from django.conf import settings
 from django.db import transaction
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext_lazy as _lazy
 from django.utils.safestring import mark_safe
 from django.core.exceptions import ValidationError
 
@@ -590,10 +590,10 @@ class PersonImporter:
 
 # Dictionary to translate internal keys to UI strings.
 WARNING_DESCRIPTIONS = {
-    ExcelImporter.W_NAME: _("Name mismatches"),
-    ExcelImporter.W_INACTIVE: _("Inactive users"),
-    ExcelImporter.W_EMAIL: _("Email mismatches"),
-    ExcelImporter.W_DUPL: _("Possible duplicates"),
-    ExcelImporter.W_GENERAL: _("General warnings"),
-    EnrollmentImporter.W_MANY: _("Unusually high number of enrollments")
+    ExcelImporter.W_NAME: _lazy("Name mismatches"),
+    ExcelImporter.W_INACTIVE: _lazy("Inactive users"),
+    ExcelImporter.W_EMAIL: _lazy("Email mismatches"),
+    ExcelImporter.W_DUPL: _lazy("Possible duplicates"),
+    ExcelImporter.W_GENERAL: _lazy("General warnings"),
+    EnrollmentImporter.W_MANY: _lazy("Unusually high number of enrollments")
 }

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -590,10 +590,10 @@ class PersonImporter:
 
 # Dictionary to translate internal keys to UI strings.
 WARNING_DESCRIPTIONS = {
-    ExcelImporter.W_NAME: _("Name mismatches"),
-    ExcelImporter.W_INACTIVE: _("Inactive users"),
-    ExcelImporter.W_EMAIL: _("Email mismatches"),
-    ExcelImporter.W_DUPL: _("Possible duplicates"),
-    ExcelImporter.W_GENERAL: _("General warnings"),
-    EnrollmentImporter.W_MANY: _("Unusually high number of enrollments")
+    ExcelImporter.W_NAME: "Name mismatches",
+    ExcelImporter.W_INACTIVE: "Inactive users",
+    ExcelImporter.W_EMAIL: "Email mismatches",
+    ExcelImporter.W_DUPL: "Possible duplicates",
+    ExcelImporter.W_GENERAL: "General warnings",
+    EnrollmentImporter.W_MANY: "Unusually high number of enrollments"
 }

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -590,10 +590,10 @@ class PersonImporter:
 
 # Dictionary to translate internal keys to UI strings.
 WARNING_DESCRIPTIONS = {
-    ExcelImporter.W_NAME: "Name mismatches",
-    ExcelImporter.W_INACTIVE: "Inactive users",
-    ExcelImporter.W_EMAIL: "Email mismatches",
-    ExcelImporter.W_DUPL: "Possible duplicates",
-    ExcelImporter.W_GENERAL: "General warnings",
-    EnrollmentImporter.W_MANY: "Unusually high number of enrollments"
+    ExcelImporter.W_NAME: _("Name mismatches"),
+    ExcelImporter.W_INACTIVE: _("Inactive users"),
+    ExcelImporter.W_EMAIL: _("Email mismatches"),
+    ExcelImporter.W_DUPL: _("Possible duplicates"),
+    ExcelImporter.W_GENERAL: _("General warnings"),
+    EnrollmentImporter.W_MANY: _("Unusually high number of enrollments")
 }

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -3,7 +3,7 @@ import xlrd
 
 from django.conf import settings
 from django.db import transaction
-from django.utils.translation import ugettext as _, ugettext_lazy as _lazy
+from django.utils.translation import ugettext_lazy, ugettext as _
 from django.utils.safestring import mark_safe
 from django.core.exceptions import ValidationError
 
@@ -590,10 +590,10 @@ class PersonImporter:
 
 # Dictionary to translate internal keys to UI strings.
 WARNING_DESCRIPTIONS = {
-    ExcelImporter.W_NAME: _lazy("Name mismatches"),
-    ExcelImporter.W_INACTIVE: _lazy("Inactive users"),
-    ExcelImporter.W_EMAIL: _lazy("Email mismatches"),
-    ExcelImporter.W_DUPL: _lazy("Possible duplicates"),
-    ExcelImporter.W_GENERAL: _lazy("General warnings"),
-    EnrollmentImporter.W_MANY: _lazy("Unusually high number of enrollments")
+    ExcelImporter.W_NAME: ugettext_lazy("Name mismatches"),
+    ExcelImporter.W_INACTIVE: ugettext_lazy("Inactive users"),
+    ExcelImporter.W_EMAIL: ugettext_lazy("Email mismatches"),
+    ExcelImporter.W_DUPL: ugettext_lazy("Possible duplicates"),
+    ExcelImporter.W_GENERAL: ugettext_lazy("General warnings"),
+    EnrollmentImporter.W_MANY: ugettext_lazy("Unusually high number of enrollments")
 }

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -2,11 +2,9 @@ from django.template import Library
 
 from evap.staff.importers import WARNING_DESCRIPTIONS
 
-from django.utils.translation import ugettext_lazy as _
-
 register = Library()
 
 
 @register.filter(name='warningname')
 def warningname(warning):
-    return _(WARNING_DESCRIPTIONS.get(warning))
+    return WARNING_DESCRIPTIONS.get(warning)

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -2,9 +2,11 @@ from django.template import Library
 
 from evap.staff.importers import WARNING_DESCRIPTIONS
 
+from django.utils.translation import ugettext_lazy as _
+
 register = Library()
 
 
 @register.filter(name='warningname')
 def warningname(warning):
-    return WARNING_DESCRIPTIONS.get(warning)
+    return _(WARNING_DESCRIPTIONS.get(warning))


### PR DESCRIPTION
This fixes #1206 by using `ugettext_lazy` to translate `WARNING_DESCRIPTORS` of the importer.