### PR TITLE
Css fixes

### DIFF
--- a/evap/evaluation/templates/footer.html
+++ b/evap/evaluation/templates/footer.html
@@ -1,10 +1,10 @@
 <div class="footer d-print-none">
     <div class="color-bar">
-        <div class="vote-bg-1" style="width: 52%;"></div>
-        <div class="vote-bg-2" style="width: 26%;"></div>
-        <div class="vote-bg-3" style="width: 13%;"></div>
-        <div class="vote-bg-4" style="width: 6%;"></div>
-        <div class="vote-bg-5" style="width: 3%;"></div>
+        <div class="vote-bg-green" style="width: 52%;"></div>
+        <div class="vote-bg-lime" style="width: 26%;"></div>
+        <div class="vote-bg-yellow" style="width: 13%;"></div>
+        <div class="vote-bg-orange" style="width: 6%;"></div>
+        <div class="vote-bg-red" style="width: 3%;"></div>
     </div>
     <nav class="navbar navbar-dark bg-dark navbar-expand">
         <div class="collapse navbar-collapse justify-content-between">

--- a/evap/static/css/_vote-elements.scss
+++ b/evap/static/css/_vote-elements.scss
@@ -138,7 +138,7 @@ div.preview > textarea {
     .left, .right {
         position: absolute;
         top: 0;
-        line-height: 1.5rem;
+        line-height: 1.6em;
         color: $darker-gray;
         font-size: 0.9rem;
         @include bar-shadow($white);

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -476,6 +476,15 @@ button:not(:disabled) {
     body, span, div, table, tr, tbody, tfoot, td, hr {
         -webkit-print-color-adjust: exact;
     }
+    .distribution-bar-container {
+        .adjective {
+            display: unset !important;
+            font-size: unset;
+        }
+        .fas {
+            display: none;
+        }
+    }
 }
 
 .breadcrumb {


### PR DESCRIPTION
- Resolve #1302 by always showing the adjectives and hiding the icons for bipolar results
- Footer now has the colors back which were stolen by the bipolar renames