### PR TITLE
include course degree and type in the excel export

### DIFF
--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -44,6 +44,7 @@ class ExcelExporter(object):
             'border_left_right': xlwt.easyxf('borders: left medium, right medium'),
             'border_top_bottom_right': xlwt.easyxf('borders: top medium, bottom medium, right medium'),
             'border_top':       xlwt.easyxf('borders: top medium'),
+            'degree':           xlwt.easyxf('alignment: wrap on; borders: left medium, right medium'),
         }
 
         grade_base_style = 'pattern: pattern solid, fore_colour {}; alignment: horiz centre; font: bold on; borders: left medium, right medium'
@@ -119,6 +120,14 @@ class ExcelExporter(object):
 
             for evaluation, results in evaluations_with_results:
                 writec(self, evaluation.full_name, "evaluation")
+
+            writen(self, _("Course Degrees"), "bold")
+            for evaluation, results in evaluations_with_results:
+                writec(self, "\n".join([d.name for d in evaluation.course.degrees.all()]), "degree")
+
+            writen(self, _("Course Type"), "bold")
+            for evaluation, results in evaluations_with_results:
+                writec(self, evaluation.course.type.name, "border_left_right")
 
             writen(self)
             for evaluation, results in evaluations_with_results:

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -50,17 +50,17 @@ class TestExporters(TestCase):
         binary_content.seek(0)
         workbook = xlrd.open_workbook(file_contents=binary_content.read())
 
-        self.assertEqual(workbook.sheets()[0].row_values(2)[0], questionnaire_1.name)
-        self.assertEqual(workbook.sheets()[0].row_values(3)[0], question_1.text)
+        self.assertEqual(workbook.sheets()[0].row_values(4)[0], questionnaire_1.name)
+        self.assertEqual(workbook.sheets()[0].row_values(5)[0], question_1.text)
 
-        self.assertEqual(workbook.sheets()[0].row_values(5)[0], questionnaire_2.name)
-        self.assertEqual(workbook.sheets()[0].row_values(6)[0], question_2.text)
+        self.assertEqual(workbook.sheets()[0].row_values(7)[0], questionnaire_2.name)
+        self.assertEqual(workbook.sheets()[0].row_values(8)[0], question_2.text)
 
-        self.assertEqual(workbook.sheets()[0].row_values(8)[0], questionnaire_3.name)
-        self.assertEqual(workbook.sheets()[0].row_values(9)[0], question_3.text)
+        self.assertEqual(workbook.sheets()[0].row_values(10)[0], questionnaire_3.name)
+        self.assertEqual(workbook.sheets()[0].row_values(11)[0], question_3.text)
 
-        self.assertEqual(workbook.sheets()[0].row_values(11)[0], questionnaire_4.name)
-        self.assertEqual(workbook.sheets()[0].row_values(12)[0], question_4.text)
+        self.assertEqual(workbook.sheets()[0].row_values(13)[0], questionnaire_4.name)
+        self.assertEqual(workbook.sheets()[0].row_values(14)[0], question_4.text)
 
     def test_heading_question_filtering(self):
         evaluation = mommy.make(Evaluation, state='published', _participant_count=2, _voter_count=2)
@@ -81,10 +81,10 @@ class TestExporters(TestCase):
         binary_content.seek(0)
         workbook = xlrd.open_workbook(file_contents=binary_content.read())
 
-        self.assertEqual(workbook.sheets()[0].row_values(2)[0], questionnaire.name)
-        self.assertEqual(workbook.sheets()[0].row_values(3)[0], heading_question.text)
-        self.assertEqual(workbook.sheets()[0].row_values(4)[0], likert_question.text)
-        self.assertEqual(workbook.sheets()[0].row_values(5)[0], "")
+        self.assertEqual(workbook.sheets()[0].row_values(4)[0], questionnaire.name)
+        self.assertEqual(workbook.sheets()[0].row_values(5)[0], heading_question.text)
+        self.assertEqual(workbook.sheets()[0].row_values(6)[0], likert_question.text)
+        self.assertEqual(workbook.sheets()[0].row_values(7)[0], "")
 
     def test_view_excel_file_sorted(self):
         semester = mommy.make(Semester)


### PR DESCRIPTION
does the first part of #1274: adds two new lines to the excel export for the degrees (comma-separated) and the type of the course of evaluations