### PR TITLE
UI changes for bipolar scales

### DIFF
--- a/evap/results/templates/distribution_with_grade.html
+++ b/evap/results/templates/distribution_with_grade.html
@@ -14,10 +14,10 @@
         {% endwith %}
     </div>
     {% if question_result.question.is_bipolar_likert_question %}
-        <span class="left pole-icon fas fa-minus"></span>
+        <span class="left pole-icon fas fa-caret-down"></span>
         <span class="left adjective">{{ question_result.choices.minus_name }}</span>
         <span class="middle"></span>
-        <span class="right pole-icon fas fa-plus"></span>
+        <span class="right pole-icon fas fa-caret-up"></span>
         <span class="right adjective">{{ question_result.choices.plus_name }}</span>
     {% endif %}
     {% if weight_sum and evaluation.course.evaluation_count > 1 %}

--- a/evap/static/scss/components/_distribution-bar.scss
+++ b/evap/static/scss/components/_distribution-bar.scss
@@ -44,6 +44,8 @@
     .pole-icon {
         color: $white;
         @include bar-shadow($medium-gray);
+        font-size: 1.4rem;
+        line-height: 1em;
     }
 
     &:not(:hover) .adjective,

--- a/evap/static/scss/evap.scss
+++ b/evap/static/scss/evap.scss
@@ -7,6 +7,7 @@
 @import "components";
 @import "adjustments";
 @import "utilities";
+@import "print";
 
 html {
     position: relative;


### PR DESCRIPTION
i suggest changing the icons in bipolar scales from plus/minus to carets pointing up and down to avoid associations with plus = good and minus = bad.
![bipolar](https://user-images.githubusercontent.com/1781719/58426356-7fddb300-809c-11e9-86c8-31ef7cf7cf07.PNG)

also, the print layout needs improvements: the icons are barely visible because the shadow is missing and the adjectives are never shown because one can not hover on elements printed on paper.
so we should discuss whether the adjectives should be always shown in print view (or maybe also in the standard view if there is sufficient space?).