### PR TITLE
Speed up results index

### DIFF
--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -178,8 +178,9 @@ class TestReloadTestdataCommand(TestCase):
 class TestRefreshResultsCacheCommand(TestCase):
     def test_calls_collect_results(self):
         mommy.make(Evaluation)
-        with patch('evap.results.tools.collect_results') as mock:
-            management.call_command('refresh_results_cache', stdout=StringIO())
+
+        with patch('evap.evaluation.management.commands.refresh_results_cache.collect_results') as mock:
+            management.call_command('refresh_results_cache')
 
         self.assertEqual(mock.call_count, Evaluation.objects.count())
 

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -102,9 +102,9 @@
     </div>
     <div class="card card-noflex">
         <div class="card-body pt-0 pb-2">
-            {% if courses %}
+            {% if courses_and_evaluations %}
                 <div id="results-grid">
-                    {% for course, evaluations in courses %}
+                    {% for course, evaluations in courses_and_evaluations %}
                         {# this is the reason why results_index_evaluation does not need to include is_subentry in the cache key: an evaluation is a subentry or no subentry regardless of which user asks #}
                         {% if course.num_evaluations > 1 %}
                             <div>

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -102,19 +102,19 @@
     </div>
     <div class="card card-noflex">
         <div class="card-body pt-0 pb-2">
-            {% if evaluations %}
+            {% if courses %}
                 <div id="results-grid">
-                    {% regroup evaluations by course as course_evaluations %}
-                    {% for course, evaluations in course_evaluations|dictsort:"grouper.name" %}
-                        {% if course.evaluations.count > 1 %}
+                    {% for course, evaluations in courses %}
+                        {# this is the reason why results_index_evaluation does not need to include is_subentry in the cache key: an evaluation is a subentry or no subentry regardless of which user asks #}
+                        {% if course.num_evaluations > 1 %}
                             <div>
                                 {% include 'results_index_course.html' %}
-                                {% for evaluation in evaluations|dictsort:"name" %}
+                                {% for evaluation in evaluations %}
                                     {% include 'results_index_evaluation.html' with links_to_results_page=evaluation|can_results_page_be_seen_by:request.user is_subentry=True %}
                                 {% endfor %}
                             </div>
                         {% else %}
-                            {% for evaluation in evaluations|dictsort:"name" %}
+                            {% for evaluation in evaluations %}
                                 {% include 'results_index_evaluation.html' with links_to_results_page=evaluation|can_results_page_be_seen_by:request.user is_subentry=False %}
                             {% endfor %}
                         {% endif %}

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -1,26 +1,93 @@
 from unittest.mock import patch
 
 from django.contrib.auth.models import Group
+from django.core.cache import caches
+from django.core.management import call_command
 from django.test.testcases import TestCase
+from django.db import connection
+from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 
 from django_webtest import WebTest
 from model_mommy import mommy
 
 from evap.evaluation.models import (Contribution, Course, Degree, Evaluation, Question, Questionnaire, RatingAnswerCounter,
                                     Semester, UserProfile)
-from evap.evaluation.tests.tools import WebTestWith200Check, let_user_vote_for_evaluation
-from evap.results.views import get_evaluations_with_prefetched_data
+from evap.evaluation.tests.tools import WebTestWith200Check, let_user_vote_for_evaluation, FuzzyInt
+from evap.results.views import get_evaluations_with_prefetched_data, get_course_result_template_fragment_cache_key
 
-import random
-
-
-class TestResultsView(WebTestWith200Check):
+class TestResultsView(WebTest):
     url = '/results/'
-    test_users = ['manager']
 
-    @classmethod
-    def setUpTestData(cls):
-        mommy.make(UserProfile, username='manager', email="manager@institution.example.com")
+    @patch('evap.evaluation.models.Evaluation.can_be_seen_by', new=lambda self, user: True)
+    def test_multiple_evaluations_per_course(self):
+        mommy.make(UserProfile, username='student', email="student@institution.example.com")
+
+        # course with no evaluations does not show up
+        course = mommy.make(Course)
+        page = self.app.get(self.url, user="student")
+        self.assertNotContains(page, course.name)
+        caches['results'].clear()
+
+        # course with one evaluation is a single line with the evaluation's full_name
+        evaluation = mommy.make(Evaluation, course=course, name_en='unique_evaluation_name1', name_de="foo", state='published')
+        page = self.app.get(self.url, user="student")
+        self.assertContains(page, evaluation.full_name)
+        caches['results'].clear()
+
+        # course with two evaluations is three lines without using the full names
+        evaluation2 = mommy.make(Evaluation, course=course, name_en='unique_evaluation_name2', name_de="bar", state='published')
+        page = self.app.get(self.url, user="student")
+        self.assertContains(page, course.name)
+        self.assertContains(page, evaluation.name_en)
+        self.assertContains(page, evaluation2.name_en)
+        self.assertNotContains(page, evaluation.full_name)
+        self.assertNotContains(page, evaluation2.full_name)
+        caches['results'].clear()
+
+    # using LocMemCache so the cache queries don't show up in the query count that's measured here
+    @override_settings(CACHES = {
+        'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache', 'LOCATION': 'testing_cache_default'},
+        'sessions': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache', 'LOCATION': 'testing_cache_results'},
+        'results': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache', 'LOCATION': 'testing_cache_sessions'},
+    })
+    @patch('evap.evaluation.models.Evaluation.can_be_seen_by', new=lambda self, user: True)
+    def test_num_queries_is_constant(self):
+        """
+            ensures that the number of queries in the user list is constant
+            and not linear to the number of courses/evaluations
+        """
+        mommy.make(UserProfile, username='student', email="student@institution.example.com")
+
+        # warm up some caches
+        self.app.get(self.url, user="student")
+
+        def make_course_with_evaluations(unique_suffix):
+            course = mommy.make(Course)
+            mommy.make(Evaluation, course=course, name_en='foo' + unique_suffix, name_de='foo' + unique_suffix, state='published', _voter_count=0)
+            mommy.make(Evaluation, course=course, name_en='bar' + unique_suffix, name_de='bar' + unique_suffix, state='published', _voter_count=0)
+
+        # first measure the number of queries with two courses
+        make_course_with_evaluations('frob')
+        make_course_with_evaluations('spam')
+        call_command("refresh_results_cache")
+        with CaptureQueriesContext(connection) as context:
+            self.app.get(self.url, user="student")
+        num_queries_before = context.final_queries - context.initial_queries
+
+        # then measure the number of queries with one more course and compare
+        make_course_with_evaluations('eggs')
+        call_command("refresh_results_cache")
+        with CaptureQueriesContext(connection) as context:
+            self.app.get(self.url, user="student")
+        num_queries_after = context.final_queries - context.initial_queries
+
+        self.assertEqual(num_queries_before, num_queries_after)
+
+        # django does not clear the LocMemCache in between tests. clear it hear just to be safe.
+        caches['default'].clear()
+        caches['sessions'].clear()
+        caches['results'].clear()
 
 
 class TestGetEvaluationsWithPrefetchedData(TestCase):

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -13,13 +13,16 @@ from model_mommy import mommy
 
 from evap.evaluation.models import (Contribution, Course, Degree, Evaluation, Question, Questionnaire, RatingAnswerCounter,
                                     Semester, UserProfile)
-from evap.evaluation.tests.tools import WebTestWith200Check, let_user_vote_for_evaluation, FuzzyInt
-from evap.results.views import get_evaluations_with_prefetched_data, get_course_result_template_fragment_cache_key
+from evap.evaluation.tests.tools import WebTestWith200Check, let_user_vote_for_evaluation
+from evap.results.views import get_evaluations_with_prefetched_data
+
+import random
+
 
 class TestResultsView(WebTest):
     url = '/results/'
 
-    @patch('evap.evaluation.models.Evaluation.can_be_seen_by', new=lambda self, user: True)
+    @patch('evap.evaluation.models.Evaluation.can_be_seen_by', new=(lambda self, user: True))
     def test_multiple_evaluations_per_course(self):
         mommy.make(UserProfile, username='student', email="student@institution.example.com")
 
@@ -46,12 +49,12 @@ class TestResultsView(WebTest):
         caches['results'].clear()
 
     # using LocMemCache so the cache queries don't show up in the query count that's measured here
-    @override_settings(CACHES = {
+    @override_settings(CACHES={
         'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache', 'LOCATION': 'testing_cache_default'},
         'sessions': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache', 'LOCATION': 'testing_cache_results'},
         'results': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache', 'LOCATION': 'testing_cache_sessions'},
     })
-    @patch('evap.evaluation.models.Evaluation.can_be_seen_by', new=lambda self, user: True)
+    @patch('evap.evaluation.models.Evaluation.can_be_seen_by', new=(lambda self, user: True))
     def test_num_queries_is_constant(self):
         """
             ensures that the number of queries in the user list is constant
@@ -84,7 +87,7 @@ class TestResultsView(WebTest):
 
         self.assertEqual(num_queries_before, num_queries_after)
 
-        # django does not clear the LocMemCache in between tests. clear it hear just to be safe.
+        # django does not clear the LocMemCache in between tests. clear it here just to be safe.
         caches['default'].clear()
         caches['sessions'].clear()
         caches['results'].clear()

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from io import StringIO
 
 from django.contrib.auth.models import Group
 from django.core.cache import caches
@@ -73,14 +74,14 @@ class TestResultsView(WebTest):
         # first measure the number of queries with two courses
         make_course_with_evaluations('frob')
         make_course_with_evaluations('spam')
-        call_command("refresh_results_cache")
+        call_command("refresh_results_cache", stdout=StringIO())
         with CaptureQueriesContext(connection) as context:
             self.app.get(self.url, user="student")
         num_queries_before = context.final_queries - context.initial_queries
 
         # then measure the number of queries with one more course and compare
         make_course_with_evaluations('eggs')
-        call_command("refresh_results_cache")
+        call_command("refresh_results_cache", stdout=StringIO())
         with CaptureQueriesContext(connection) as context:
             self.app.get(self.url, user="student")
         num_queries_after = context.final_queries - context.initial_queries

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -11,7 +11,7 @@ from django.template.loader import get_template
 from django.contrib.auth.decorators import login_required
 from django.utils import translation
 
-from evap.evaluation.models import Semester, Degree, Evaluation, CourseType, UserProfile
+from evap.evaluation.models import Semester, Degree, Evaluation, CourseType, UserProfile, Course
 from evap.evaluation.auth import internal_required
 from evap.results.tools import (collect_results, calculate_average_distribution, distribution_to_grade,
                                 get_evaluations_with_course_result_attributes, get_single_result_rating_result,
@@ -122,7 +122,9 @@ def get_evaluations_with_prefetched_data(evaluations):
 @internal_required
 def index(request):
     semesters = Semester.get_all_with_published_unarchived_results()
+    # we need to prefetch the number of evaluations per course.
     evaluations = Evaluation.objects.filter(course__semester__in=semesters, state='published')
+    evaluations = evaluations.select_related('course', 'course__semester')
     evaluations = [evaluation for evaluation in evaluations if evaluation.can_be_seen_by(request.user)]
 
     if request.user.is_reviewer:
@@ -135,13 +137,26 @@ def index(request):
         additional_evaluations = get_evaluations_with_course_result_attributes(additional_evaluations)
         evaluations += additional_evaluations
 
-    evaluations.sort(key=lambda evaluation: (evaluation.course.semester.pk, evaluation.full_name))  # evaluations must be sorted for regrouping them in the template
+    # put evaluations into a dict that maps from course to a list of evaluations.
+    # this dict is sorted by course.pk (important for the zip below)
+    # (this relies on python 3.7's guarantee that the insertion order of the dict is preserved)
+    evaluations.sort(key=lambda evaluation: evaluation.course.pk)
 
-    evaluation_pks = [evaluation.pk for evaluation in evaluations]
-    degrees = Degree.objects.filter(courses__evaluations__pk__in=evaluation_pks).distinct()
-    course_types = CourseType.objects.filter(courses__evaluations__pk__in=evaluation_pks).distinct()
+    courses = defaultdict(list)
+    for evaluation in evaluations:
+        courses[evaluation.course].append(evaluation)
+
+    course_pks = list([course.pk for course in courses.keys()])
+
+    # annotate each course in courses with num_evaluations
+    annotated_courses = Course.objects.filter(pk__in=course_pks).annotate(num_evaluations=Count('evaluations')).order_by('pk').defer()
+    for course, annotated_course in zip(courses.keys(), annotated_courses):
+        course.num_evaluations = annotated_course.num_evaluations
+
+    degrees = Degree.objects.filter(courses__pk__in=course_pks).distinct()
+    course_types = CourseType.objects.filter(courses__pk__in=course_pks).distinct()
     template_data = dict(
-        evaluations=evaluations,
+        courses=courses.items(),
         degrees=degrees,
         course_types=course_types,
         semesters=semesters,


### PR DESCRIPTION
By bringing it back to O(1) queries again

This speeds up the request time for students from 8s to 1.5s on my laptop and from 23 to 15s for staff users

Note that this is not the complete loading time for this page. my browser (firefox) needs another six seconds to finish processing/rendering the page.