### PR TITLE
Save the language in the user's session on first visit

### DIFF
--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core import management
 from django.urls import reverse
 from django.test.testcases import TestCase
@@ -8,24 +9,21 @@ from django.utils import translation
 from model_mommy import mommy
 
 from evap.evaluation.tests.tools import WebTest
-from evap.evaluation.tools import set_or_get_language
 from evap.evaluation.models import UserProfile
 
 
 class TestLanguageSignalReceiver(WebTest):
     def test_signal_sets_language_if_none(self):
         """
-        Activate 'de' as language and check that user gets this as initial language as he has None.
+        Check that a user gets the default language set if they have none
         """
-        translation.activate('de')
-
         user = mommy.make(UserProfile, language=None, email="user@institution.example.com")
         user.ensure_valid_login_key()
 
-        set_or_get_language(user=user, request=None)
+        self.app.get("/", user=user)
 
         user.refresh_from_db()
-        self.assertEqual(user.language, 'de')
+        self.assertEqual(user.language, settings.LANGUAGE_CODE)
 
     def test_signal_doesnt_set_language(self):
         """

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -80,11 +80,11 @@ def date_to_datetime(date):
 @receiver(user_logged_in)
 def set_or_get_language(user, request, **_kwargs):
     if user.language:
-        request.session[LANGUAGE_SESSION_KEY] = user.language
         translation.activate(user.language)
     else:
         user.language = get_language()
         user.save()
+    request.session[LANGUAGE_SESSION_KEY] = user.language
 
 
 def get_due_evaluations_for_user(user):

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -207,12 +207,14 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    # LocaleMiddleware should be here according to https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#how-django-discovers-language-preference
+    # Furthermore, set_or_get_language (happens on login) uses the active language, so LocaleMiddleware should be before AuthenticationMiddleware
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
 ]
 
 TEMPLATES = [

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -352,12 +352,15 @@ class TestSemesterView(WebTest):
             course=mommy.make(Course, name_de="B", name_en="A", semester=cls.semester))
 
     def test_view_list_sorting(self):
-        page = self.app.get(self.url, user='manager', extra_environ={'HTTP_ACCEPT_LANGUAGE': 'en'}).body.decode("utf-8")
+        UserProfile.objects.filter(username='manager').update(language='en')
+        page = self.app.get(self.url, user='manager').body.decode("utf-8")
         position_evaluation1 = page.find("Evaluation 1")
         position_evaluation2 = page.find("Evaluation 2")
         self.assertGreater(position_evaluation1, position_evaluation2)
+        self.app.reset() # language is only loaded on login, so we're forcing a re-login here
 
-        page = self.app.get(self.url, user='manager', extra_environ={'HTTP_ACCEPT_LANGUAGE': 'de'}).body.decode("utf-8")
+        UserProfile.objects.filter(username='manager').update(language='de')
+        page = self.app.get(self.url, user='manager').body.decode("utf-8")
         position_evaluation1 = page.find("Evaluation 1")
         position_evaluation2 = page.find("Evaluation 2")
         self.assertLess(position_evaluation1, position_evaluation2)


### PR DESCRIPTION
This resolves the following inconsistency: If a user first visits the page, the brower's language gets written to user.language, but is not saved in the session. If the user now changes the browser's language, EvaP's language will also change. However, if the user logs out and logs in again, changing the browser's language will not change EvaP's language, because on the second login, the user.language will be written to the session.

@He3lixxx tripped over this while writing tests for the results cache, see #1229.

