### PR TITLE
Contributor results export

### DIFF
--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -37,6 +37,9 @@
                 <em>{% trans 'More details:' %} <a href="/faq#3-s">{% trans 'FAQ/Results' %}</a></em>
             </div>
         </div>
+        <div class="mb-auto ml-2 d-print-none">
+            <a href="{% url 'contributor:export' %}" class="btn btn-sm btn-light">{% trans 'Export results' %}</a>
+        </div>
         {% if user.is_delegate %}
             <div class="btn-switch btn-switch-light mb-auto ml-2 d-print-none">
                 <div class="btn-switch-label"><span class="fas fa-user-circle"></span> {% trans 'Delegated evaluations' %}</div>

--- a/evap/contributor/urls.py
+++ b/evap/contributor/urls.py
@@ -8,6 +8,7 @@ app_name = "contributor"
 urlpatterns = [
     path("", views.index, name="index"),
     path("settings", views.settings_edit, name="settings_edit"),
+    path("export", views.export, name="export"),
     path("evaluation/<int:evaluation_id>", views.evaluation_view, name="evaluation_view"),
     path("evaluation/<int:evaluation_id>/edit", views.evaluation_edit, name="evaluation_edit"),
     path("evaluation/<int:evaluation_id>/preview", views.evaluation_preview, name="evaluation_preview"),

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -131,7 +131,12 @@ class ExcelExporter(object):
             ), "headline")
 
             for evaluation, results in evaluations_with_results:
-                writec(self, evaluation.full_name, "evaluation")
+                title = evaluation.full_name
+                if len(semesters) > 1:
+                    title += "\n{}".format(evaluation.course.semester.name)
+                responsible_names = [responsible.full_name for responsible in evaluation.course.responsibles.all()]
+                title += "\n{}".format(", ".join(responsible_names))
+                writec(self, title, "evaluation")
 
             writen(self, _("Degrees"), "bold")
             for evaluation, results in evaluations_with_results:

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -125,7 +125,7 @@
         </div>
     {% endif %}
 
-    {% if contributor_contribution_results or other_contributors %}
+    {% if contributor_contribution_results or contributors_with_omitted_results %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
                 {% trans 'Contributors' %}
@@ -160,14 +160,14 @@
                         </div>
                     </div>
                 {% endfor %}
-                {% if other_contributors %}
+                {% if contributors_with_omitted_results %}
                     <div class="card mt-3">
                         <div class="card-header">
                             {% trans 'Other contributors' %}
                         </div>
                         <div class="card-body">
                             <ul>
-                                {% for contributor in other_contributors %}
+                                {% for contributor in contributors_with_omitted_results %}
                                     <li>{{ contributor.full_name }}</li>
                                 {% endfor %}
                             </ul>

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -125,7 +125,7 @@
         </div>
     {% endif %}
 
-    {% if contributor_contribution_results %}
+    {% if contributor_contribution_results or other_contributors %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
                 {% trans 'Contributors' %}
@@ -160,7 +160,7 @@
                         </div>
                     </div>
                 {% endfor %}
-                {% if view == 'export' and other_contributors %}
+                {% if other_contributors %}
                     <div class="card mt-3">
                         <div class="card-header">
                             {% trans 'Other contributors' %}

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -144,12 +144,12 @@ class TestExporters(TestCase):
 
         # Load responses as Excel files and check for correct sorting
         workbook = xlrd.open_workbook(file_contents=content_de.read())
-        self.assertEqual(workbook.sheets()[0].row_values(0)[1], "A – Evaluation1")
-        self.assertEqual(workbook.sheets()[0].row_values(0)[2], "B – Evaluation2")
+        self.assertEqual(workbook.sheets()[0].row_values(0)[1], "A – Evaluation1\n")
+        self.assertEqual(workbook.sheets()[0].row_values(0)[2], "B – Evaluation2\n")
 
         workbook = xlrd.open_workbook(file_contents=content_en.read())
-        self.assertEqual(workbook.sheets()[0].row_values(0)[1], "A – Evaluation2")
-        self.assertEqual(workbook.sheets()[0].row_values(0)[2], "B – Evaluation1")
+        self.assertEqual(workbook.sheets()[0].row_values(0)[1], "A – Evaluation2\n")
+        self.assertEqual(workbook.sheets()[0].row_values(0)[2], "B – Evaluation1\n")
 
     def test_course_type_ordering(self):
         degree = baker.make(Degree)
@@ -183,8 +183,8 @@ class TestExporters(TestCase):
         binary_content.seek(0)
         workbook = xlrd.open_workbook(file_contents=binary_content.read())
 
-        self.assertEqual(workbook.sheets()[0].row_values(0)[1], evaluation_1.full_name)
-        self.assertEqual(workbook.sheets()[0].row_values(0)[2], evaluation_2.full_name)
+        self.assertEqual(workbook.sheets()[0].row_values(0)[1], evaluation_1.full_name + "\n")
+        self.assertEqual(workbook.sheets()[0].row_values(0)[2], evaluation_2.full_name + "\n")
 
         course_type_2.order = 0
         course_type_2.save()
@@ -194,5 +194,5 @@ class TestExporters(TestCase):
         binary_content.seek(0)
         workbook = xlrd.open_workbook(file_contents=binary_content.read())
 
-        self.assertEqual(workbook.sheets()[0].row_values(0)[1], evaluation_2.full_name)
-        self.assertEqual(workbook.sheets()[0].row_values(0)[2], evaluation_1.full_name)
+        self.assertEqual(workbook.sheets()[0].row_values(0)[1], evaluation_2.full_name + "\n")
+        self.assertEqual(workbook.sheets()[0].row_values(0)[2], evaluation_1.full_name + "\n")

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -11,7 +11,7 @@ from evap.results.exporters import ExcelExporter
 
 class TestExporters(TestCase):
     def test_grade_color_calculation(self):
-        exporter = ExcelExporter(Semester())
+        exporter = ExcelExporter()
         self.assertEqual(exporter.STEP, 0.2)
         self.assertEqual(exporter.normalize_number(1.94999999999), 1.8)
         # self.assertEqual(exporter.normalize_number(1.95), 2.0)  # floats ftw
@@ -53,8 +53,9 @@ class TestExporters(TestCase):
         baker.make(RatingAnswerCounter, question=question_4, contribution=evaluation.general_contribution, answer=3, count=100)
 
         binary_content = BytesIO()
-        ExcelExporter(evaluation.course.semester).export(
+        ExcelExporter().export(
             binary_content,
+            [evaluation.course.semester],
             [([course_degree.id for course_degree in evaluation.course.degrees.all()], [evaluation.course.type.id])],
             True,
             True
@@ -96,8 +97,9 @@ class TestExporters(TestCase):
         baker.make(RatingAnswerCounter, question=likert_question, contribution=contribution, answer=3, count=100)
 
         binary_content = BytesIO()
-        ExcelExporter(evaluation.course.semester).export(
+        ExcelExporter().export(
             binary_content,
+            [evaluation.course.semester],
             [([course_degree.id for course_degree in evaluation.course.degrees.all()], [evaluation.course.type.id])],
             True,
             True
@@ -131,11 +133,11 @@ class TestExporters(TestCase):
 
         content_de = BytesIO()
         with translation.override("de"):
-            ExcelExporter(semester).export(content_de, [([degree.id], [course_type.id])], True, True)
+            ExcelExporter().export(content_de, [semester], [([degree.id], [course_type.id])], True, True)
 
         content_en = BytesIO()
         with translation.override("en"):
-            ExcelExporter(semester).export(content_en, [([degree.id], [course_type.id])], True, True)
+            ExcelExporter().export(content_en, [semester], [([degree.id], [course_type.id])], True, True)
 
         content_de.seek(0)
         content_en.seek(0)
@@ -177,7 +179,7 @@ class TestExporters(TestCase):
         baker.make(RatingAnswerCounter, question=question, contribution=evaluation_2.general_contribution, answer=3, count=2)
 
         binary_content = BytesIO()
-        ExcelExporter(semester).export(binary_content, [([degree.id], [course_type_1.id, course_type_2.id])], True, True)
+        ExcelExporter().export(binary_content, [semester], [([degree.id], [course_type_1.id, course_type_2.id])], True, True)
         binary_content.seek(0)
         workbook = xlrd.open_workbook(file_contents=binary_content.read())
 
@@ -188,7 +190,7 @@ class TestExporters(TestCase):
         course_type_2.save()
 
         binary_content = BytesIO()
-        ExcelExporter(semester).export(binary_content, [([degree.id], [course_type_1.id, course_type_2.id])], True, True)
+        ExcelExporter().export(binary_content, [semester], [([degree.id], [course_type_1.id, course_type_2.id])], True, True)
         binary_content.seek(0)
         workbook = xlrd.open_workbook(file_contents=binary_content.read())
 

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -4,6 +4,7 @@ from model_bakery import baker
 from django.test import TestCase
 from django.utils import translation
 
+from evap.contributor.views import export_contributor_results
 from evap.evaluation.models import (Contribution, Course, CourseType, Degree, Evaluation, Question, Questionnaire,
                                     RatingAnswerCounter, Semester, UserProfile)
 from evap.results.exporters import ExcelExporter
@@ -196,3 +197,65 @@ class TestExporters(TestCase):
 
         self.assertEqual(workbook.sheets()[0].row_values(0)[1], evaluation_2.full_name + "\n")
         self.assertEqual(workbook.sheets()[0].row_values(0)[2], evaluation_1.full_name + "\n")
+
+    def test_contributor_result_export(self):
+        degree = baker.make(Degree)
+        course_type_1 = baker.make(CourseType, order=1)
+        course_type_2 = baker.make(CourseType, order=2)
+        semester_1 = baker.make(Semester)
+        semester_2 = baker.make(Semester)
+        contributor = baker.make(UserProfile)
+        other_contributor = baker.make(UserProfile)
+        evaluation_1 = baker.make(
+            Evaluation,
+            course=baker.make(Course, semester=semester_1, degrees=[degree], type=course_type_1, responsibles=[contributor]),
+            state='published',
+            _participant_count=10,
+            _voter_count=1
+        )
+        evaluation_2 = baker.make(
+            Evaluation,
+            course=baker.make(Course, semester=semester_2, degrees=[degree], type=course_type_2, responsibles=[other_contributor]),
+            state='published',
+            _participant_count=2,
+            _voter_count=2,
+        )
+        contribution = baker.make(
+            Contribution,
+            evaluation=evaluation_2,
+            contributor=contributor,
+        )
+        other_contribution = baker.make(
+            Contribution,
+            evaluation=evaluation_2,
+            contributor=other_contributor,
+        )
+
+        general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        general_question = baker.make(Question, type=Question.LIKERT, questionnaire=general_questionnaire)
+        contributor_question = baker.make(Question, type=Question.LIKERT, questionnaire=contributor_questionnaire)
+
+        evaluation_1.general_contribution.questionnaires.set([general_questionnaire])
+        baker.make(RatingAnswerCounter, question=general_question, contribution=evaluation_1.general_contribution, answer=1, count=2)
+        evaluation_2.general_contribution.questionnaires.set([general_questionnaire])
+        baker.make(RatingAnswerCounter, question=general_question, contribution=evaluation_2.general_contribution, answer=4, count=2)
+
+        contribution.questionnaires.set([contributor_questionnaire])
+        baker.make(RatingAnswerCounter, question=contributor_question, contribution=contribution, answer=3, count=2)
+        other_contribution.questionnaires.set([contributor_questionnaire])
+        baker.make(RatingAnswerCounter, question=contributor_question, contribution=other_contribution, answer=2, count=2)
+
+        binary_content = export_contributor_results(contributor).content
+        workbook = xlrd.open_workbook(file_contents=binary_content)
+
+        self.assertEqual(workbook.sheets()[0].row_values(0)[1], "{}\n{}\n{}".format(evaluation_1.full_name, semester_1.name, contributor.full_name))
+        self.assertEqual(workbook.sheets()[0].row_values(0)[2], "{}\n{}\n{}".format(evaluation_2.full_name, semester_2.name, other_contributor.full_name))
+        self.assertEqual(workbook.sheets()[0].row_values(4)[0], general_questionnaire.name)
+        self.assertEqual(workbook.sheets()[0].row_values(5)[0], general_question.text)
+        self.assertEqual(workbook.sheets()[0].row_values(5)[2], 4.0)
+        self.assertEqual(workbook.sheets()[0].row_values(7)[0], "{} ({})".format(contributor_questionnaire.name, contributor.full_name))
+        self.assertEqual(workbook.sheets()[0].row_values(8)[0], contributor_question.text)
+        self.assertEqual(workbook.sheets()[0].row_values(8)[2], 3.0)
+        self.assertEqual(workbook.sheets()[0].row_values(10)[0], "Overall Average Grade")
+        self.assertEqual(workbook.sheets()[0].row_values(10)[2], 3.25)

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -248,9 +248,9 @@ def evaluation_detail(request, semester_id, evaluation_id):
                 course_evaluation.distribution = calculate_average_distribution(course_evaluation)
                 course_evaluation.avg_grade = distribution_to_grade(course_evaluation.distribution)
 
-    other_contributors = []
+    contributors_with_omitted_results = []
     if view == 'export':
-        other_contributors = [contribution_result.contributor for contribution_result in evaluation_result.contribution_results if contribution_result.contributor not in [None, view_as_user]]
+        contributors_with_omitted_results = [contribution_result.contributor for contribution_result in evaluation_result.contribution_results if contribution_result.contributor not in [None, view_as_user]]
 
     # if the evaluation is not published, the rendered results are not cached, so we need to attach distribution
     # information for rendering the distribution bar
@@ -270,7 +270,7 @@ def evaluation_detail(request, semester_id, evaluation_id):
         can_download_grades=view_as_user.can_download_grades,
         view=view,
         view_as_user=view_as_user,
-        other_contributors=other_contributors,
+        contributors_with_omitted_results=contributors_with_omitted_results,
     )
     return render(request, "results_evaluation_detail.html", template_data)
 

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -50,23 +50,22 @@
                             </div>
                         </div>
                         <ul>
-                            {% for semester, evaluations in evaluations_contributing_to %}
-                                {% if evaluations %}
-                                    <li>{{ semester.name }}</li>
-                                    <ul>
-                                        {% for evaluation in evaluations %}
-                                            <li>
-                                                {% if evaluation|can_results_page_be_seen_by:form.instance %}
-                                                    <a href="{% url 'results:evaluation_detail' semester.id evaluation.id %}?view=export&contributor_id={{ form.instance.id }}">
-                                                        {{ evaluation.full_name }}
-                                                    </a>
-                                                {% else %}
+                            {% regroup evaluations_contributing_to by course.semester as evaluation_list %}
+                            {% for semester_evaluations in evaluation_list %}
+                                <li>{{ semester_evaluations.grouper.name }}</li>
+                                <ul>
+                                    {% for evaluation in semester_evaluations.list %}
+                                        <li>
+                                            {% if evaluation|can_results_page_be_seen_by:form.instance %}
+                                                <a href="{% url 'results:evaluation_detail' semester_evaluations.grouper.id evaluation.id %}?view=export&contributor_id={{ form.instance.id }}">
                                                     {{ evaluation.full_name }}
-                                                {% endif %}
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
+                                                </a>
+                                            {% else %}
+                                                {{ evaluation.full_name }}
+                                            {% endif %}
+                                        </li>
+                                    {% endfor %}
+                                </ul>
                             {% endfor %}
                         </ul>
                     </div>

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -43,7 +43,12 @@
             {% if evaluations_contributing_to %}
                 <div class="card mb-3">
                     <div class="card-body">
-                        <h5 class="card-title">{% trans 'Export result pages' %}</h5>
+                        <div class="d-flex">
+                            <h5 class="card-title mr-auto">{% trans 'Export evaluation results' %}</h5>
+                            <div>
+                                <a href="{% url 'staff:export_contributor_results' form.instance.id %}" class="btn btn-sm btn-light">{% trans 'Export all results' %}</a>
+                            </div>
+                        </div>
                         <ul>
                             {% for semester, evaluations in evaluations_contributing_to %}
                                 {% if evaluations %}

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -752,7 +752,7 @@ class TestSemesterExportView(WebTest):
         workbook = xlrd.open_workbook(file_contents=response.content)
         self.assertEqual(
             workbook.sheets()[0].row_values(0)[0],
-            'Evaluation {}\n\n{}\n\n{}'.format(self.semester.name, self.degree.name, self.course_type.name)
+            'Evaluation\n{}\n\n{}\n\n{}'.format(self.semester.name, self.degree.name, self.course_type.name)
         )
 
 

--- a/evap/staff/urls.py
+++ b/evap/staff/urls.py
@@ -80,4 +80,6 @@ urlpatterns = [
     path("download_sample_xls/<str:filename>", views.download_sample_xls, name="download_sample_xls"),
 
     path("development/components", views.development_components, name="development_components"),
+
+    path("export_contributor_results/<int:contributor_id>", views.export_contributor_results_view, name="export_contributor_results"),
 ]

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1491,8 +1491,9 @@ def user_edit(request, user_id):
     user = get_object_or_404(UserProfile, id=user_id)
     form = UserForm(request.POST or None, request.FILES or None, instance=user)
 
-    semesters_with_evaluations = Semester.objects.filter(courses__evaluations__contributions__contributor=user).distinct()
-    evaluations_contributing_to = [(semester, Evaluation.objects.filter(course__semester=semester, contributions__contributor=user)) for semester in semesters_with_evaluations]
+    evaluations_contributing_to = Evaluation.objects.filter(
+        Q(contributions__contributor=user) | Q(course__responsibles__in=[user])
+    ).distinct().order_by('course__semester')
 
     if form.is_valid():
         form.save()

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -480,8 +480,8 @@ def semester_export(request, semester_id):
         filename = "Evaluation-{}-{}.xls".format(semester.name, get_language())
         response = HttpResponse(content_type="application/vnd.ms-excel")
         response["Content-Disposition"] = "attachment; filename=\"{}\"".format(filename)
-        ExcelExporter(semester).export(
-            response, selection_list, include_not_enough_voters, include_unpublished
+        ExcelExporter().export(
+            response, [semester], selection_list, include_not_enough_voters, include_unpublished
         )
         return response
     else:

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -18,6 +18,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.utils.translation import get_language, ungettext, ngettext
 from django.views.decorators.http import require_POST
+from evap.contributor.views import export_contributor_results
 from evap.evaluation.auth import reviewer_required, manager_required
 from evap.evaluation.models import (Contribution, Course, CourseType, Degree, EmailTemplate, Evaluation, FaqQuestion,
                                     FaqSection, Question, Questionnaire, RatingAnswerCounter, Semester, TextAnswer,
@@ -1642,3 +1643,9 @@ def development_components(request):
         'theme_colors': theme_colors
     }
     return render(request, "staff_development_components.html", template_data)
+
+
+@manager_required
+def export_contributor_results_view(request, contributor_id):
+    contributor = get_object_or_404(UserProfile, id=contributor_id)
+    return export_contributor_results(contributor)

--- a/evap/static/scss/components/_callouts.scss
+++ b/evap/static/scss/components/_callouts.scss
@@ -56,6 +56,7 @@
     &.closed {
         border-radius: .2rem;
         border-left-width: 0;
+        padding: 4px 8px 4px 8px;
 
         .callout-content {
             max-height: 0;
@@ -69,7 +70,7 @@
     }
 
     &.closing {
-        transition: border-radius 1s ease 1s, border-left-width 1s ease 1s;
+        transition: border-radius 1s ease 1s, border-left-width 1s ease 1s, padding 1s ease-in-out;
 
         .callout-content {
             transition: max-width 1s ease 1s, padding-top 1s ease, max-height 1s ease;
@@ -77,7 +78,7 @@
     }
 
     &.opening {
-        transition: border-radius 1s ease, border-left-width 1s ease;
+        transition: border-radius 1s ease, border-left-width 1s ease, padding 1s ease-in-out;
 
         .callout-content {
             transition: max-width 1s ease, padding-top 1s ease 1s, max-height 1s ease 1s;


### PR DESCRIPTION
Fix #1378 
This PR adds the functionality to export an Excel sheet with the results for all evaluations a specific user has contributed to or is responsible for. This export can be accessed from each contributor's index page and for managers from the user's UserProfile edit page.

Open todos:
- [x] Write tests