### PR TITLE
issue #1392: added warning badges for external responsibles

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -324,6 +324,10 @@ class Course(models.Model):
         return ", ".join([responsible.full_name for responsible in self.responsibles.all().order_by("last_name")])
 
     @property
+    def has_external_responsible(self):
+        return any(responsible.is_external for responsible in self.responsibles.all())
+
+    @property
     def all_evaluations_finished(self):
         return not self.evaluations.exclude(state__in=['evaluated', 'reviewed', 'published']).exists()
 

--- a/evap/evaluation/templates/evaluation_badges.html
+++ b/evap/evaluation/templates/evaluation_badges.html
@@ -12,4 +12,7 @@
     {% if not evaluation.course.is_graded %}<span class="badge badge-dark">{% trans 'not graded' %}</span>{% endif %}
     {% if not evaluation.is_rewarded %}<span class="badge badge-dark">{% trans 'not rewarded' %}</span>{% endif %}
     {% if evaluation.course.is_private %}<span class="badge badge-dark">{% trans 'private' %}</span>{% endif %}
+    {% if evaluation.course.has_external_responsible %}
+        <span class="badge badge-warning">{% trans 'External responsible' %}</span>
+    {% endif %}
 {% endif %}

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -380,7 +380,7 @@ class TestSemesterView(WebTest):
     def test_badge_for_external_responsibles(self):
         responsible = mommy.make(UserProfile, email='a@institution.com')
         course = mommy.make(Course, semester=self.semester, responsibles=[responsible])
-        evaluation = mommy.make(Evaluation, course=course)
+        mommy.make(Evaluation, course=course)
         response = self.app.get(self.url, user='manager')
         self.assertNotContains(response, 'External responsible')
 

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -376,6 +376,19 @@ class TestSemesterView(WebTest):
         # managers can access the page
         self.app.get('/staff/semester/2', user='manager', status=200)
 
+    @override_settings(INSTITUTION_EMAIL_DOMAINS=["institution.com"])
+    def test_badge_for_external_responsibles(self):
+        responsible = mommy.make(UserProfile, email='a@institution.com')
+        course = mommy.make(Course, semester=self.semester, responsibles=[responsible])
+        evaluation = mommy.make(Evaluation, course=course)
+        response = self.app.get(self.url, user='manager')
+        self.assertNotContains(response, 'External responsible')
+
+        responsible.email = 'r@external.com'
+        responsible.save()
+        response = self.app.get(self.url, user='manager')
+        self.assertContains(response, 'External responsible')
+
 
 class TestGetEvaluationsWithPrefetchedData(TestCase):
     def test_get_evaluations_with_prefetched_data(self):


### PR DESCRIPTION
added warning badges for external responsibles in staff semester view and belonging tests.
fixes #1392