### PR TITLE
Fixes duplicate course name detection when importing semester

### DIFF
--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -278,9 +278,10 @@ class EnrollmentImporter(ExcelImporter):
 
     def check_evaluation_data_correctness(self, semester):
         for evaluation_data in self.evaluations.values():
-            already_exists = Evaluation.objects.filter(course__semester=semester, name_de=evaluation_data.name_de).exists()
-            if already_exists:
+            if Course.objects.filter(semester=semester, name_en=evaluation_data.name_en).exists():
                 self.errors.append(_("Course {} does already exist in this semester.").format(evaluation_data.name_en))
+            if Course.objects.filter(semester=semester, name_de=evaluation_data.name_de).exists():
+                self.errors.append(_("Course {} does already exist in this semester.").format(evaluation_data.name_de))
 
         degree_names = set()
         for evaluation_data in self.evaluations.values():

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -220,6 +220,19 @@ class TestEnrollmentImporter(TestCase):
         self.assertIn('Errors occurred while parsing the input data. No data was imported.', errors_test)
         self.assertEqual(UserProfile.objects.count(), original_user_count)
 
+    def test_duplicate_course_error(self):
+        with open(self.filename_valid, "rb") as excel_file:
+            excel_content = excel_file.read()
+
+        semester = baker.make(Semester)
+        baker.make(Course, name_de="Stehlen", name_en="Stehlen", semester=semester)
+        baker.make(Course, name_de="Shine", name_en="Shine", semester=semester)
+
+        __, __, errors = EnrollmentImporter.process(excel_content, semester, None, None, test_run=False)
+
+        self.assertIn("Course Stehlen does already exist in this semester.", errors)
+        self.assertIn("Course Shine does already exist in this semester.", errors)
+
 
 class TestPersonImporter(TestCase):
     @classmethod


### PR DESCRIPTION
Fixes #1390 

Duplicates were checked in the evaluations, but since these do not have names, a duplicate could never be detected.
The check is now performed on the courses instead.

@janno42 can you confirm?