### PR TITLE
Restore auto-configuration with `vagrant ssh-config`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
   # this user, so mounting before does not work with an owner specified by name.
   # Also, provision needs to use vagrant as ssh user (since evap does not exist yet)
   config.vm.synced_folder ".", "/evap", mount_options: ["uid=1042", "gid=1042"]
-  if ARGV[0] == "ssh"
+  if ARGV[0] == "ssh" or ARGV[0] == "ssh-config"
     config.ssh.username = 'evap'
   end
 


### PR DESCRIPTION
The user for the vagrant ssh session was changed to `evap` in aea829ecd91d4af356fd79bf87d7386935eea614. But, some clients (like pycharm) try to fetch all necessary info for connecting with `vagrant ssh-config` which was not updated yet, so they try to login with `vagrant`.

I did a quick check for other commands where this setting would be beneficial, but I think the two `ssh` commands should suffice.