### PR TITLE
Fix ordering by grade on results index

### DIFF
--- a/evap/static/js/datagrid.js
+++ b/evap/static/js/datagrid.js
@@ -48,7 +48,7 @@ class DataGrid {
                 for (const column of this.sortableHeaders.keys()) {
                     const cell = $(row).find(`[data-col=${column}]`);
                     if (cell.is("[data-order]")) {
-                        orderValues.set(column, cell.data("order"));
+                        orderValues.set(column, cell.attr("data-order"));
                     } else {
                         orderValues.set(column, cell.html().trim());
                     }


### PR DESCRIPTION
Closes #1425.

Always use strings for order keys as mixed types will result in incomparable types